### PR TITLE
Fixed the /list route arguments get issue

### DIFF
--- a/server.py
+++ b/server.py
@@ -138,8 +138,8 @@ def count_handler():
 
 @app.route('/list', methods=['GET'])
 def list_handler():
-    offset = max(int(request.form.get('offset', 0)), 0)
-    limit = max(int(request.form.get('limit', 20)), 0)
+    offset = max(int(request.args.get('offset', 0)), 0)
+    limit = max(int(request.args.get('limit', 20)), 0)
     paths = paths_at_location(offset, limit)
 
     return json.dumps({


### PR DESCRIPTION
The arguments given by a GET request on the /list route were not getting received by the elasicsearch, due to a wrong method call.