### PR TITLE
Fixed small python version incompatibility issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3.6
 MAINTAINER Alex Kern <alex@distributedsystems.com>
 
 RUN apt-get update && \


### PR DESCRIPTION
The newest version (at this time) of python is not compatible with some of the pip modules, which prevents the Docker image from building. Python 3.6 however is.